### PR TITLE
Run autoreconf for match libtool/lt_init versions

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -34,6 +34,7 @@ class SnappyConan(ConanFile):
        if self.settings.os == "Macos":
            replace_in_file("./autogen.sh", "libtoolize", "glibtoolize")
        self.run("%s ./autogen.sh" % (env.command_line))
+       self.run("%s autoreconf --force --install" % (env.command_line))
        self.run("%s ./configure prefix=\"%s/distr\" %s" % (env.command_line,
            self.conanfile_directory, shared_definition))
        self.run("%s make install" % env.command_line)


### PR DESCRIPTION
It fixes following error:

<pre>
libtool: Version mismatch error.  This is libtool 2.4.2 Debian-2.4.2-1.7ubuntu1, but the
libtool: definition of this LT_INIT comes from libtool 2.2.6b.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.2 Debian-2.4.2-1.7ubuntu1
libtool: and run autoconf again.
</pre>